### PR TITLE
Update dependencies

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,7 @@
         sourcemaps = require('gulp-sourcemaps'),
         rollup = require('rollup-stream'),
         buble = require('rollup-plugin-buble'),
-        vue = require('rollup-plugin-vue'),
+        vue = require('rollup-plugin-vue2'),
         source = require('vinyl-source-stream'),
         buffer = require('vinyl-buffer'),
         rename = require('gulp-rename'),

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "android"
   ],
   "author": "Vladimir Kharlampidi",
+  "contributors": [
+    "Paul Hendry <paul@pshendry.com>"
+  ],
   "license": "MIT",
   "scripts": {
     "dev": "cross-env NODE_ENV=development webpack-dev-server --content-base kitchen-sink/ --open --inline --hot",
@@ -50,14 +53,14 @@
     "gulp-rename": "^1.2.2",
     "gulp-sourcemaps": "^2.2.1",
     "gulp-uglify": "^2.0.0",
-    "rollup": "^0.36.4",
-    "rollup-plugin-buble": "^0.14.0",
-    "rollup-plugin-vue": "^2.2.10",
+    "rollup": "^0.37.0",
+    "rollup-plugin-buble": "^0.15.0",
+    "rollup-plugin-vue2": "^0.6.1",
     "rollup-stream": "^1.14.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
-    "vue": "^2.1.3",
-    "vue-loader": "^9.9.5",
+    "vue": "^2.1.6",
+    "vue-loader": "^10.0.2",
     "vue-template-compiler": "^2.1.3",
     "webpack": "^1.13.3",
     "webpack-dev-server": "^1.16.2"


### PR DESCRIPTION
* Fix `npm run dist` throwing errors
* Will fix the error in #19 once a new distributable is built

To be honest, I can't tell even from the READMEs what the difference is between `rollup-plugin-vue` and `rollup-plugin-vue2`; both seem to support Vue 2. `npm run dist` was failing for me under `rollup-plugin-vue` though (it couldn't handle `.vue` files without `<template>` tags), whereas `rollup-plugin-vue2` worked fine for me. One of the authors of `rollup-plugin-vue2` is the original author of the other library, so it seems like that's the one to switch to.

Other than that I bumped the dependencies up, in particular `vue` since v2.1.5 introduced some internal changes that broke plugins built using prior versions of Vue.

Since this plugin is currently broken for the latest version of Vue, I'm hoping you can put out a patch release with these changes assuming they make sense to you.