### PR TITLE
Add submit event for searchbar to allow custom search on submit

### DIFF
--- a/src/components/searchbar.vue
+++ b/src/components/searchbar.vue
@@ -45,6 +45,7 @@
       return c(self.form ? 'form' : 'div', {
         staticClass: 'searchbar',
         on: {
+          'submit': self.onSubmit,
           'searchbar:search': self.onSearch,
           'searchbar:enable': self.onEnable,
           'searchbar:disable': self.onDisable,
@@ -118,6 +119,9 @@
       },
       onBlur: function (event) {
         this.$emit('blur', event);
+      },
+      onSubmit: function (event) {
+        this.$emit('submit', event);
       },
       onSearch: function (event) {
         if(!event.detail) return;


### PR DESCRIPTION
When using the searchbar with custom search it is useful to have the search form's submit event triggered so for example you can send ajax request with the device keyboard / enter key. 