### PR TITLE
Issue #65: add overlay when picker-modal is shown

### DIFF
--- a/src/components/picker-modal.vue
+++ b/src/components/picker-modal.vue
@@ -53,9 +53,11 @@
         var self = this;
         if (!self.$f7) return;
         if (opened) {
+          Dom7('.picker-modal-overlay').addClass('modal-overlay-visible');
           self.$f7.pickerModal(self.$el)
         }
         else {
+          Dom7('.picker-modal-overlay').removeClass('modal-overlay-visible');
           self.$f7.closeModal(self.$el)
         }
       }


### PR DESCRIPTION
The picker-modal when shown in Material does not show the overlay. I have put in a fix for it but I'm not 100% sure if this is the correct way to do it in Vue.js but it is a good start for a conversation on the correct way.