### PR TITLE
Add routing check for options.reload or view.allowDuplicateUrls

### DIFF
--- a/src/components/pages.vue
+++ b/src/components/pages.vue
@@ -71,10 +71,15 @@
         var pageComponent = event.route.component;
         var view = event.view;
         var currentView = self.$parent.f7View || self.$parent.$el.f7View;
-        
-        const alreadyOnPage = view.url === event.route.pagePath;
 
-        if (view === currentView && !alreadyOnPage) {
+        if (view !== currentView) return;
+
+        const previousRoute = self.$router.findMatchingRoute(view.url) || { route: { path: '/', pagePath: '/' } };
+        const pageRouteChanged = previousRoute.route.pagePath !== event.route.pagePath;
+        const childRouteChanged = !pageRouteChanged && previousRoute.route.path !== event.route.path;
+        const shouldUpdatePages = pageRouteChanged || (!childRouteChanged && (event.options.reload || view.params.allowDuplicateUrls))        
+
+        if (shouldUpdatePages) {
           var id = new Date().getTime();
 
           self.$set(self.pages, id, {component: pageComponent});

--- a/src/framework7-vue.js
+++ b/src/framework7-vue.js
@@ -122,7 +122,8 @@ export default {
     var f7Ready = false,
         f7Instance,
         currentRoute,
-        f7Router;
+        f7Router,
+        router;
 
     function initFramework7(f7Params) {
       if (!window.Framework7) return;
@@ -136,7 +137,7 @@ export default {
       // Init
       f7Instance = Vue.prototype.$f7 = window.f7 = new window.Framework7(f7Params);
 
-      var router = new Framework7Router(f7Params.routes, f7Instance, $$);      
+      router = new Framework7Router(f7Params.routes, f7Instance, $$);      
 
       router.setRouteChangeHandler(route => {
         currentRoute = route;
@@ -162,8 +163,17 @@ export default {
         var self = this;
 
         // Route
-        self.$route = currentRoute;
-        self.$router = f7Router;        
+        Object.defineProperty(self, '$route', {
+          get: () => currentRoute,
+          enumerable: true,
+          configurable: true
+        });
+
+        Object.defineProperty(self, '$router', {
+          get: () => router,
+          enumerable: true,
+          configurable: true
+        });
 
         // Theme
         if (theme.ios === false && theme.material === false) {


### PR DESCRIPTION
This should get it closer to how it is supposed to work. In the case of options.reload, should the existing page get replaced instead of adding a new page? If so, then that's not how it works in the master branch either.