### PR TITLE
file-input error fix

### DIFF
--- a/kitchen-sink/pages/forms.vue
+++ b/kitchen-sink/pages/forms.vue
@@ -51,6 +51,10 @@
         <f7-label>Textarea</f7-label>
         <f7-input type="textarea" placeholder="Textarea"></f7-input>
       </f7-list-item>
+      <f7-list-item>
+        <f7-label>File</f7-label>
+        <f7-input type="file"></f7-input>
+      </f7-list-item>
     </f7-list>
 
     <f7-block-title>Form With Floating Labels</f7-block-title>

--- a/src/components/form-input.vue
+++ b/src/components/form-input.vue
@@ -57,7 +57,7 @@
 	      wheel: self.onWheel,
 	      select: self.onSelect
       }
-      if (self.type === 'select' || self.type === 'textarea') {
+      if (self.type === 'select' || self.type === 'textarea' || self.type === 'file') {
         delete attrs.value;
         if (self.type === 'select') {
           if (self.hasSelectModel) {
@@ -66,6 +66,9 @@
           else {
             inputEl = c('select', {attrs: attrs, on: on, domProps: {value: self.valueComputed}}, self.$slots.default);
           }
+        }
+        else if (self.type === 'file') {
+          inputEl = c('input', {attrs: attrs}, self.$slots.default);
         }
         else {
           inputEl = c('textarea', {attrs: attrs, on: on, domProps: {value: self.valueComputed}}, self.$slots.default);


### PR DESCRIPTION
That fixes the problem #84  - possible improvement: nice-looking button to start file selection process

Error: DOMException: Failed to set the 'value' property on
'HTMLInputElement': This input element accepts a filename, which may
only be programmatically set to the empty string.