### PR TITLE
List item click event fired twice - part 2

### DIFF
--- a/src/components/list-item.vue
+++ b/src/components/list-item.vue
@@ -251,8 +251,10 @@
       }
     },
     methods: {
-      onClick: function (event) {
-        this.$emit('click', event)
+      onClick: function (event) {        
+        if (event.currentTarget.tagName.toLowerCase() !== 'a' || event.target.tagName.toLowerCase() !== 'input') {
+          this.$emit('click', event)
+        }        
       },
       onSwipeoutDeleted: function (event) {
         this.$emit('swipeout:deleted', event)


### PR DESCRIPTION
In addition to the issue I fixed in PR #90, there is another scenario where the list item click event fires twice. It occurs when a list item is both a link and a checkbox (or radio):

```javascript
<f7-list-item title="Content Block" :link="true" checkbox></f7-list-item>
```

Similar to #90, this fiddle illustrates what is happening:

https://jsfiddle.net/1219v2tk/

Normally, the click event will not fire twice because [this code](http://github.com/nolimits4web/Framework7/blob/233085927c386c973c20d665e739bea2bf622b2e/src/js/framework7/clicks.js#L253) in Framework7 will call `preventDefault()` and keep input from changing its `checked` value and then firing the click event again on the anchor tag. However, when the Framework7 parameter `router` is false, [this code](http://github.com/nolimits4web/Framework7/blob/233085927c386c973c20d665e739bea2bf622b2e/src/js/framework7/clicks.js#L250) makes it exit before `preventDefault()` can get called. 

This may seem like a bit of an obscure scenario, but in my app, I currently have the router disabled because I'm using Framework7 Redux to do my navigation, and I also have list items that are both checkboxes and links (as I described in #90).


### Edit

I also noticed that `<f7-list-item link title="...">...` doesn't make the list-item render an anchor tag. It only renders an anchor when either a boolean or a string is passed into the link prop (e.g., `:link="true"` or `link="/some-url/"`). Probably just needs to use that trustyBoolean function to convert the empty string to a bool.