### PR TITLE
Panel overlay click event

### DIFF
--- a/src/components/panel.vue
+++ b/src/components/panel.vue
@@ -6,6 +6,7 @@
     @panel:opened="onOpened"
     @panel:close="onClose"
     @panel:closed="onClosed"
+    @panel:overlay-click="onOverlayClick"
   >
     <slot></slot>
   </div>
@@ -76,12 +77,15 @@
       onClosed: function (event) {
         this.$emit('panel:closed', event);
       },
+      onOverlayClick(event) {
+        this.$emit('panel:overlay-click', event);
+      },      
       onF7Init: function () {
         var $$ = this.$$
         if (!$$) return;
         if ($$('.panel-overlay').length === 0) {
           $$('<div class="panel-overlay"></div>').insertBefore(this.$el)
-        }
+        }        
       },
       open: function () {
         var self = this;

--- a/src/components/panel.vue
+++ b/src/components/panel.vue
@@ -85,7 +85,7 @@
         if (!$$) return;
         if ($$('.panel-overlay').length === 0) {
           $$('<div class="panel-overlay"></div>').insertBefore(this.$el)
-        }        
+        }
       },
       open: function () {
         var self = this;


### PR DESCRIPTION
With the Panel component, it is currently possible to have the `opened` prop set to true, but have the panel be closed because the user clicked the overlay. This is especially problematic when using VueX / Redux to control whether a panel should be open, since the panel can close without VueX or Redux knowing about it.

Framework7 offers the `panelsCloseByOutside` param to keep panels from closing when the overlay is clicked. That provides part of the solution, but the other part is to have an overlay click event on the Panel component. This event can be used to dispatch a VueX / Redux action, and then the resulting state can be used to determine whether or not the panel should be open.

In addition to adding the overlay click event to Framework7 Vue, I also needed to add it to Framework7 in [this PR](https://github.com/nolimits4web/Framework7/pull/1344).