### PR TITLE
Checkbox click event not firing on touch devices

### DIFF
--- a/src/components/list-item-content.vue
+++ b/src/components/list-item-content.vue
@@ -110,10 +110,8 @@
       'disabled': Boolean
     },
     methods: {
-      onClick: function (event) {
-        if (event.currentTarget.tagName.toLowerCase() !== 'label' || event.target.tagName.toLowerCase() === 'input') {
-          this.$emit('click', event)
-        }        
+      onClick: function (event) {        
+          this.$emit('click', event);          
       },
       onChange: function (event) {
         this.$emit('change', event);

--- a/src/components/list-item.vue
+++ b/src/components/list-item.vue
@@ -254,10 +254,10 @@
       }
     },
     methods: {
-      onClick: function (event) {        
-        if (event.currentTarget.tagName.toLowerCase() !== 'a' || event.target.tagName.toLowerCase() !== 'input') {
-          this.$emit('click', event)
-        }        
+      onClick: function (event) {
+        if (event.target.tagName.toLowerCase() !== 'input') {
+          this.$emit('click', event);            
+        }         
       },
       onSwipeoutDeleted: function (event) {
         this.$emit('swipeout:deleted', event)


### PR DESCRIPTION
It turns out that my fix in PR #92 prevents the click event from firing at all for checkboxes when the click event originates from a touch event. To reproduce, test on a mobile device or with Chrome in Device Mode, click a checkbox, and notice that the click event for checkboxes does not get fired. This is because the input doesn't fire a second click event for touch events.

To prevent any further regressions, I decided to take a more rigorous approach. First, I created the following example ListItems:

```javascript
<f7-list-item title="Checkbox" checkbox></f7-list-item>
<f7-list-item title="Checkbox + link" checkbox :link="true"></f7-list-item>
<f7-list-item title="Link only" :link="true"></f7-list-item>
<f7-list-item title="Radio" radio></f7-list-item>
<f7-list-item title="Radio + link" radio :link="true"></f7-list-item>
<f7-list-item title="Plain list item"></f7-list-item>
```

Then I tested and created the following scenario table:

|Scenario #|List Item Configuration|List Item Click 1 Target|List Item Click 1 CurrentTarget|List Item Click 2 Target|List Item Click 2 Current Target|Touch|Router|
|---|--------|-----|-----|-----|-----|-----|-----|
|1|Checkbox|DIV|LABEL|INPUT|LABEL|FALSE|FALSE|
|2|Checkbox + link|DIV|A|INPUT|A|FALSE|FALSE|
|3|Link only|DIV|A|-|-|FALSE|FALSE|
|4|Radio|DIV|LABEL|INPUT|LABEL|FALSE|FALSE|
|5|Radio + link|DIV|A|INPUT|A|FALSE|FALSE|
|6|Plain|DIV|DIV|-|-|FALSE|FALSE|
|7|Checkbox|DIV|LABEL|-|-|TRUE|FALSE|
|8|Checkbox + link|DIV|A|-|-|TRUE|FALSE|
|9|Link only|DIV|A|-|-|TRUE|FALSE|
|10|Radio|DIV|LABEL|-|-|TRUE|FALSE|
|11|Radio + link|DIV|A|-|-|TRUE|FALSE|
|12|Plain|DIV|DIV|-|-|TRUE|FALSE|
|13|Checkbox|DIV|LABEL|INPUT|LABEL|FALSE|TRUE|
|14|Checkbox + link|DIV|A|-|-|FALSE|TRUE|
|15|Link only|DIV|A|-|-|FALSE|TRUE|
|16|Radio|DIV|LABEL|INPUT|LABEL|FALSE|TRUE|
|17|Radio + link|DIV|A|-|-|FALSE|TRUE|
|18|Plain|DIV|DIV|-|-|FALSE|TRUE|
|19|Checkbox|DIV|LABEL|-|-|TRUE|TRUE|
|20|Checkbox + link|DIV|A|-|-|TRUE|TRUE|
|21|Link only|DIV|A|-|-|TRUE|TRUE|
|22|Radio|DIV|LABEL|-|-|TRUE|TRUE|
|23|Radio + link|DIV|A|-|-|TRUE|TRUE|
|24|Plain|DIV|DIV|-|-|TRUE|TRUE|

As the table clearly illustrates, the second click event always has a target of "INPUT". This makes sense, because it the browser automatically checking the checkbox / radio causes a second click event to fire in the first place. Therefore, filtering out any ListItem click events that have a target of "INPUT" will reliably prevent the click event from firing twice. 

After changing the code, I tested these 24 scenarios and verified that that the click event now gets fired exactly once in each case. I also regression tested other ListItem configurations in the kitchen sink (Smart Select, Accordions, Forms) to ensure that the click event is firing correctly.