### PR TITLE
add missing closing tag for slot in content-block

### DIFF
--- a/src/components/content-block.vue
+++ b/src/components/content-block.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="content-block" :class="classesObject" @tab:show="onTabShow" @tab:hide="onTabHide">
     <div class="content-block-inner" v-if="inner">
-      <slot>
+      <slot></slot>
     </div>
     <slot v-else></slot>
   </div>


### PR DESCRIPTION
Found missing closing tag for the content-block when trying to run the kitchen sink for framework7-react and framework7-vue