### PR TITLE
firefox support for virtual list

### DIFF
--- a/src/components/list.vue
+++ b/src/components/list.vue
@@ -132,6 +132,10 @@
         if (!(self.virtual && self.virtualInit)) return;
         var $$ = self.$$;
         var template = $$(self.$el).find('script').html();
+        if(!template){
+          template = $$(self.$el).find('script')[0].outerHTML;
+          template = /\<script type="text\/template7"\>(.*)<\/script>/.exec(template)[1];
+        }
         if (!template && !self.virtualRenderItem) return;
         if (template) template = self.$t7.compile(template);
 


### PR DESCRIPTION
fixes issue #67
innerHTML on <script> tags does not work in firefox, always returns empty string
included check on innerHTML; if this is empty i try outerHTML (and remove script tag)
will not affect any setup it worked in previously