### PR TITLE
[v2] vue-router compatibility

### DIFF
--- a/src/utils/vue-plugin.js
+++ b/src/utils/vue-plugin.js
@@ -53,16 +53,16 @@ export default {
         let $router;
         let parent = self;
         while (parent && !$router && !$route) {
-          if (parent.$route) $route = parent.$route;
-          if (parent.$router) $router = parent.$router;
+          if (parent.$f7route) $route = parent.$f7route;
+          if (parent.$f7router) $router = parent.$f7router;
           else if (parent.f7View) {
             $router = parent.f7View.router;
           }
           parent = parent.$parent;
         }
 
-        self.$route = $route;
-        self.$router = $router;
+        self.$f7route = $route;
+        self.$f7router = $router;
       },
       mounted() {
         const self = this;

--- a/src/utils/vue-router.js
+++ b/src/utils/vue-router.js
@@ -17,7 +17,7 @@ export default {
         params: Utils.extend({}, options.route.params),
         route: Utils.extend({}, options.route),
       };
-      routerVue.$route = options.route;
+      routerVue.$f7route = options.route;
       routerVue.pages.push(pageData);
       routerVue.$nextTick(() => {
         const pageEl = el.childNodes[el.childNodes.length - 1];


### PR DESCRIPTION
This (partial) PR tries to resolve naming conflicts with `vue-router`. As it defines both `$route` and `$router` read only parameters on vue components we get errors like `Cannot set property $route of #<Vue$3> which has only a getter` on projects which `vue-router` exists.  So we may use a safe prefix like `$f7route` and `$f7router` :)